### PR TITLE
add bmv2 pytest mark

### DIFF
--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -716,7 +716,7 @@ run-saichallenger-tutorials: deploy-ixiac
 	-w /sai-challenger/dash_tests/functional \
 	$(DOCKER_FLAGS) \
 	$(DOCKER_SAI_CHALLENGER_CLIENT_IMG) \
-	./run-tests.sh --setup=$(SAI_CHALLENGER_SETUP_FILE) tutorial
+	./run-tests.sh -m bmv2 --setup=$(SAI_CHALLENGER_SETUP_FILE) tutorial
 
 ###############################
 # ENVIRONMENT SETUP TARGETS

--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -702,14 +702,14 @@ run-saichallenger-functional-tests: deploy-ixiac
 	-w /sai-challenger/dash_tests/functional \
 	$(DOCKER_FLAGS) \
 	$(DOCKER_SAI_CHALLENGER_CLIENT_IMG) \
-	./run-tests.sh --setup=$(SAI_CHALLENGER_SETUP_FILE) $(SAI_CHALLENGER_TEST)
+	./run-tests.sh -m bmv2 --setup=$(SAI_CHALLENGER_SETUP_FILE) $(SAI_CHALLENGER_TEST)
 
 run-saichallenger-scale-tests: deploy-ixiac
 	$(DOCKER_RUN_SAI_CHALLENGER_CLIENT) \
 	-w /sai-challenger/dash_tests/scale \
 	$(DOCKER_FLAGS) \
 	$(DOCKER_SAI_CHALLENGER_CLIENT_IMG) \
-	./run-tests.sh --setup=$(SAI_CHALLENGER_SETUP_FILE) $(SAI_CHALLENGER_TEST)
+	./run-tests.sh -m bmv2 --setup=$(SAI_CHALLENGER_SETUP_FILE) $(SAI_CHALLENGER_TEST)
 
 run-saichallenger-tutorials: deploy-ixiac
 	$(DOCKER_RUN_SAI_CHALLENGER_CLIENT) \

--- a/test/test-cases/functional/saic/tutorial/test_sai_vnet_outbound_small_scale_config_via_dpugen.py
+++ b/test/test-cases/functional/saic/tutorial/test_sai_vnet_outbound_small_scale_config_via_dpugen.py
@@ -46,6 +46,7 @@ NUMBER_OF_IN_ACL_GROUP = 0
 NUMBER_OF_OUT_ACL_GROUP = 0
 
 class TestSaiVnetOutbound:
+    @pytest.mark.bmv2
     def make_create_commands(self):
         """ Generate a configuration
             returns iterator (generator) of SAI records
@@ -54,6 +55,7 @@ class TestSaiVnetOutbound:
         conf.generate()
         return conf.items()
 
+    @pytest.mark.bmv2
     def make_remove_commands(self):
         """ Generate a configuration to remove entries
             returns iterator (generator) of SAI records
@@ -65,6 +67,7 @@ class TestSaiVnetOutbound:
         return
 
     @pytest.mark.ptf
+    @pytest.mark.bmv2
     @pytest.mark.snappi
     def test_create_vnet_scale_config_generated(self, dpu):
         """Generate and apply configuration"""
@@ -75,6 +78,7 @@ class TestSaiVnetOutbound:
 
 
     @pytest.mark.ptf
+    @pytest.mark.bmv2
     @pytest.mark.snappi
     def test_remove_vnet_scale_config_generated(self, dpu):
         """

--- a/test/test-cases/functional/saic/tutorial/test_sai_vnet_outbound_small_scale_config_via_dpugen_files.py
+++ b/test/test-cases/functional/saic/tutorial/test_sai_vnet_outbound_small_scale_config_via_dpugen_files.py
@@ -26,6 +26,7 @@ import pytest
 
 current_file_dir = Path(__file__).parent
 
+@pytest.mark.bmv2
 def test_sai_vnet_outbound_small_scale_config_create_file(dpu):
 
     with (current_file_dir / f'test_sai_vnet_outbound_small_scale_config_via_dpugen_create.json').open(mode='r') as config_file:
@@ -33,6 +34,7 @@ def test_sai_vnet_outbound_small_scale_config_create_file(dpu):
         result = [*dpu.process_commands(setup_commands)]
         pprint(result)
 
+@pytest.mark.bmv2
 def test_sai_vnet_outbound_small_scale_config_remove_file(dpu):
 
     with (current_file_dir / f'test_sai_vnet_outbound_small_scale_config_via_dpugen_remove.json').open(mode='r') as config_file:

--- a/test/test-cases/functional/saic/tutorial/test_sai_vnet_vips_config_via_custom_gen.py
+++ b/test/test-cases/functional/saic/tutorial/test_sai_vnet_vips_config_via_custom_gen.py
@@ -83,6 +83,7 @@ def make_remove_cmds(vip_start=1,a1=192, a2=193, b1=168, b2=169, c1=1,c2=2,d1=1,
 
 class TestSaiDashVipsGenerator:
     @pytest.mark.ptf
+    @pytest.mark.bmv2
     @pytest.mark.snappi
     def test_many_vips_create_via_generator(self, dpu):
         """Verify VIP configuration create
@@ -93,6 +94,7 @@ class TestSaiDashVipsGenerator:
         assert all(results), "Create error"
 
     @pytest.mark.ptf
+    @pytest.mark.bmv2
     @pytest.mark.snappi
     def test_many_vips_remove_via_generator(self, dpu):
         """Verify VIP configuration removal

--- a/test/test-cases/functional/saic/tutorial/test_sai_vnet_vips_config_via_custom_gen_files.py
+++ b/test/test-cases/functional/saic/tutorial/test_sai_vnet_vips_config_via_custom_gen_files.py
@@ -26,6 +26,7 @@ import pytest
 
 current_file_dir = Path(__file__).parent
 
+@pytest.mark.bmv2
 def test_sai_vnet_vips_config_create_file(dpu):
 
     with (current_file_dir / f'test_sai_vnet_vips_config_via_custom_gen_create.json').open(mode='r') as config_file:
@@ -35,6 +36,7 @@ def test_sai_vnet_vips_config_create_file(dpu):
         pprint(results)
         assert all(results), "Create error"
 
+@pytest.mark.bmv2
 def test_sai_vnet_outbound_small_scale_config_remove_file(dpu):
 
     with (current_file_dir / f'test_sai_vnet_vips_config_via_custom_gen_remove.json').open(mode='r') as config_file:

--- a/test/test-cases/functional/saic/tutorial/test_sai_vnet_vips_config_via_list_comprehension.py
+++ b/test/test-cases/functional/saic/tutorial/test_sai_vnet_vips_config_via_list_comprehension.py
@@ -50,6 +50,7 @@ def make_remove_cmds(vip_start=1,d1=1,d2=1):
 
 class TestSaiDashVipsListComprehension:
     @pytest.mark.ptf
+    @pytest.mark.bmv2
     @pytest.mark.snappi
     def test_many_vips_create_via_list_comprehension(self, dpu):
         """Verify VIP configuration create
@@ -60,6 +61,7 @@ class TestSaiDashVipsListComprehension:
         assert all(results), "Create error"
 
     @pytest.mark.ptf
+    @pytest.mark.bmv2
     @pytest.mark.snappi
     def test_many_vips_remove_via_list_comprehension(self, dpu):
         """Verify VIP configuration removal

--- a/test/test-cases/functional/saic/tutorial/test_sai_vnet_vips_config_via_list_comprehension_files.py
+++ b/test/test-cases/functional/saic/tutorial/test_sai_vnet_vips_config_via_list_comprehension_files.py
@@ -26,6 +26,7 @@ import pytest
 
 current_file_dir = Path(__file__).parent
 
+@pytest.mark.bmv2
 def test_sai_vnet_vips_config_create_file(dpu):
     with (current_file_dir / f'test_sai_vnet_vips_config_via_list_comprehension_create.json').open(mode='r') as config_file:
         setup_commands = json.load(config_file)
@@ -34,6 +35,7 @@ def test_sai_vnet_vips_config_create_file(dpu):
         pprint(results)
         assert all(results), "Create error"
 
+@pytest.mark.bmv2
 def test_sai_vnet_outbound_small_scale_config_remove_file(dpu):
     with (current_file_dir / f'test_sai_vnet_vips_config_via_list_comprehension_remove.json').open(mode='r') as config_file:
         teardown_commands = json.load(config_file)

--- a/test/test-cases/functional/saic/tutorial/test_sai_vnet_vips_config_via_literal.py
+++ b/test/test-cases/functional/saic/tutorial/test_sai_vnet_vips_config_via_literal.py
@@ -59,6 +59,7 @@ def make_remove_cmds():
 
 class TestSaiDashVipsLiteral:
     @pytest.mark.ptf
+    @pytest.mark.bmv2
     @pytest.mark.snappi
     def test_many_vips_create_via_literal(self, dpu):
         """Verify VIP configuration create
@@ -69,6 +70,7 @@ class TestSaiDashVipsLiteral:
         assert all(results), "Create error"
 
     @pytest.mark.ptf
+    @pytest.mark.bmv2
     @pytest.mark.snappi
     def test_many_vips_remove_via_literal(self, dpu):
         """Verify VIP configuration removal

--- a/test/test-cases/scale/saic/test_config_vnet_inbound.py
+++ b/test/test-cases/scale/saic/test_config_vnet_inbound.py
@@ -21,6 +21,7 @@ class TestConfigVnetInboundRouting:
             vnet_inbound_setup_commands = json.load(config_file)
         return vnet_inbound_setup_commands
 
+    @pytest.mark.bmv2
     def test_config_vnet_inbound_create(self, dpu, vnet_in_config):
         """
         Apply configuration that is loaded from the file.
@@ -29,6 +30,7 @@ class TestConfigVnetInboundRouting:
         result = [*dpu.process_commands(vnet_in_config)]
         # User may want to verify result.
 
+    @pytest.mark.bmv2
     def test_config_vnet_inbound_remove(self, dpu, vnet_in_config):
         """
         Remove configuration that is loaded from the file.

--- a/test/test-cases/scale/saic/test_config_vnet_outbound.py
+++ b/test/test-cases/scale/saic/test_config_vnet_outbound.py
@@ -8,6 +8,7 @@ import pytest
 
 
 # The following test function will be executed twice - against each cfg_type: simple and scale
+@pytest.mark.bmv2
 @pytest.mark.parametrize('cfg_type', ['simple', 'scale'])
 def test_config_vnet_outbound_parametrized(dpu, cfg_type):
 

--- a/test/test-cases/scale/saic/test_sai_vnet_inbound.py
+++ b/test/test-cases/scale/saic/test_sai_vnet_inbound.py
@@ -53,7 +53,7 @@ TEST_VNET_INBOUND_CONFIG = {
                         'dip': '10.0.0.1',
                         'gid': '$acl_out_1',
                         'priority': 10}
-        }
+         }
     ],
 
     'DASH_VNET': [
@@ -75,29 +75,29 @@ TEST_VNET_INBOUND_CONFIG = {
                              {'STAGE4': '$acl_out_1'},
                              {'STAGE5': '$acl_out_1'}
                              ]
-                            },
-            'ADMIN_STATE': True,
-            'CPS': 10000,
-            'FLOWS': 10000,
-            'PPS': 100000,
-            'VM_UNDERLAY_DIP': PA_VALIDATION_DIP,
-            'VM_VNI': VM_VNI,
-            'VNET_ID': '$vnet_1'}
-        }
+            },
+                'ADMIN_STATE': True,
+                'CPS': 10000,
+                'FLOWS': 10000,
+                'PPS': 100000,
+                'VM_UNDERLAY_DIP': PA_VALIDATION_DIP,
+                'VM_VNI': VM_VNI,
+                'VNET_ID': '$vnet_1'}
+         }
     ],
 
     'DASH_ENI_ETHER_ADDRESS_MAP': [
         {'address_map_1': {
             'MAC': ENI_MAC,
             'VNI': INBOUND_ROUTING_VNI}
-        }
+         }
     ],
 
     'DASH_ROUTE_RULE_TABLE': [
         {'inbound_routing_1': {
             'VNI': INBOUND_ROUTING_VNI,
             'action_type': 'DECAP_PA_VALIDATE'}
-        }
+         }
     ],
 
     'DASH_PA_VALIDATION': [
@@ -106,7 +106,7 @@ TEST_VNET_INBOUND_CONFIG = {
                              'sip': PA_VALIDATION_SIP,
                              'switch_id': SWITCH_ID,
                              'vni': INBOUND_ROUTING_VNI}
-        }
+         }
     ]
 
 }
@@ -114,6 +114,7 @@ TEST_VNET_INBOUND_CONFIG = {
 
 class TestSaiVnetInbound:
 
+    @pytest.mark.bmv2
     def test_vnet_inbound_create(self, dpu):
         """Test configuration create"""
 
@@ -129,6 +130,7 @@ class TestSaiVnetInbound:
         pprint(result)
 
     @pytest.mark.ptf
+    @pytest.mark.bmv2
     @pytest.mark.xfail(reason="https://github.com/sonic-net/DASH/issues/233")
     def test_vnet_inbound_traffic_check(self, dpu, dataplane):
         """Verify traffic forwarding in PTF style"""
@@ -140,9 +142,9 @@ class TestSaiVnetInbound:
 
         # PAcket to send
         inner_pkt = simple_udp_packet(eth_dst=ENI_MAC,
-                                        eth_src=inner_smac,
-                                        ip_dst=INNER_VM_IP,
-                                        ip_src=INNER_REMOTE_IP)
+                                      eth_src=inner_smac,
+                                      ip_dst=INNER_VM_IP,
+                                      ip_src=INNER_REMOTE_IP)
         vxlan_pkt = simple_vxlan_packet(eth_dst=outer_dmac,
                                         eth_src=outer_smac,
                                         ip_dst=PA_VALIDATION_DIP,
@@ -154,17 +156,17 @@ class TestSaiVnetInbound:
 
         # Expected Packet to check
         inner_exp_pkt = simple_udp_packet(eth_dst=inner_dmac,
-                                            eth_src=ENI_MAC,
-                                            ip_dst=INNER_VM_IP,
-                                            ip_src=INNER_REMOTE_IP)
+                                          eth_src=ENI_MAC,
+                                          ip_dst=INNER_VM_IP,
+                                          ip_src=INNER_REMOTE_IP)
         vxlan_exp_pkt = simple_vxlan_packet(eth_dst="00:00:00:00:00:00",
-                                        eth_src="00:00:00:00:00:00",
-                                        ip_dst=PA_VALIDATION_DIP,
-                                        ip_src=PA_VALIDATION_SIP,
-                                        udp_sport=11638,
-                                        with_udp_chksum=False,
-                                        vxlan_vni=INBOUND_ROUTING_VNI,
-                                        inner_frame=inner_exp_pkt)
+                                            eth_src="00:00:00:00:00:00",
+                                            ip_dst=PA_VALIDATION_DIP,
+                                            ip_src=PA_VALIDATION_SIP,
+                                            udp_sport=11638,
+                                            with_udp_chksum=False,
+                                            vxlan_vni=INBOUND_ROUTING_VNI,
+                                            inner_frame=inner_exp_pkt)
 
         # dataplane.start_capture()
         print("\nSending outbound packet...\n\n", vxlan_pkt.__repr__())
@@ -173,6 +175,7 @@ class TestSaiVnetInbound:
         print("\nVerifying packet...\n", vxlan_exp_pkt.__repr__())
         verify_packet(dataplane, vxlan_exp_pkt, 1)
 
+    @pytest.mark.bmv2
     def test_vnet_inbound_remove(self, dpu):
         """Test configuration remove"""
 

--- a/test/test-cases/scale/saic/test_sai_vnet_outbound_scale.py
+++ b/test/test-cases/scale/saic/test_sai_vnet_outbound_scale.py
@@ -119,6 +119,7 @@ class TestSaiVnetOutbound:
         return
 
     @pytest.mark.ptf
+    @pytest.mark.bmv2
     @pytest.mark.snappi
     def test_create_vnet_config(self, dpu):
         """Generate and apply configuration"""
@@ -143,6 +144,7 @@ class TestSaiVnetOutbound:
                                                                 name="Custom flow group", show=True)[0],
                     "Test", timeout_seconds=5)
 
+    @pytest.mark.bmv2
     @pytest.mark.snappi
     def test_run_traffic_check_fixed_duration(self, dpu, dataplane):
         """
@@ -161,6 +163,7 @@ class TestSaiVnetOutbound:
                     "Test", timeout_seconds=test_duration + 1)
 
     @pytest.mark.ptf
+    @pytest.mark.bmv2
     @pytest.mark.snappi
     def test_remove_vnet_config(self, dpu, dataplane):
         """

--- a/test/test-cases/scale/saic/test_sai_vnet_outbound_simple.py
+++ b/test/test-cases/scale/saic/test_sai_vnet_outbound_simple.py
@@ -125,6 +125,7 @@ TEST_VNET_OUTBOUND_CONFIG = {
 class TestSaiVnetOutbound:
 
     @pytest.mark.ptf
+    @pytest.mark.bmv2
     @pytest.mark.snappi
     def test_vnet_inbound_simple_create(self, dpu):
         """Generate and apply configuration"""
@@ -136,6 +137,7 @@ class TestSaiVnetOutbound:
         pprint(result)
 
     @pytest.mark.ptf
+    @pytest.mark.bmv2
     def test_vnet_inbound_simple_packet_modification(self, dpu, dataplane):
         """Verify proper packet transformation."""
 
@@ -244,6 +246,7 @@ class TestSaiVnetOutbound:
         print("\nVerifying packet...\n", vxlan_exp_pkt.__repr__())
         verify_packet(dataplane, vxlan_exp_pkt, 0)
 
+    @pytest.mark.bmv2
     @pytest.mark.snappi
     def test_vnet_inbound_simple_traffic_fixed_packets(self, dpu, dataplane):
         """
@@ -257,6 +260,7 @@ class TestSaiVnetOutbound:
         stu.wait_for(lambda: dh.check_flow_packets_metrics(dataplane, dataplane.flows[0], show=True)[0],
                     "Test", timeout_seconds=10)
 
+    @pytest.mark.bmv2
     @pytest.mark.snappi
     def test_vnet_inbound_simple_traffic_fixed_duration(self, dpu, dataplane):
         """
@@ -275,6 +279,7 @@ class TestSaiVnetOutbound:
                     "Test", timeout_seconds=test_duration + 1)
 
     @pytest.mark.ptf
+    @pytest.mark.bmv2
     @pytest.mark.snappi
     def test_vnet_inbound_simple_remove(self, dpu):
         """Verify configuration removal"""


### PR DESCRIPTION
as we add more cases that run on hardware but not on bmv2 we need a way to group the test cases that will run on bmv2 in CI